### PR TITLE
Open external links from the article sheet in the browser

### DIFF
--- a/app/src/main/java/com/byterdevs/rsswidget/webview/BottomSheetWebView.kt
+++ b/app/src/main/java/com/byterdevs/rsswidget/webview/BottomSheetWebView.kt
@@ -8,6 +8,9 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
+import android.webkit.WebResourceRequest
+import android.content.Intent
+import android.content.ActivityNotFoundException
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import android.widget.LinearLayout
@@ -100,6 +103,20 @@ class BottomSheetWebView(context: Context, activity: Activity, readerable: Boole
 
         webView.settings.isAlgorithmicDarkeningAllowed = true
         webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                val url = request?.url ?: return false
+                if (url.scheme == "http" || url.scheme == "https") {
+                    val context = view?.context ?: return false
+                    try {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, url))
+                    } catch (e: ActivityNotFoundException) {
+                        // no app available to open the link
+                    }
+                    return true
+                }
+                return false
+            }
+
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
 


### PR DESCRIPTION
This adds a `shouldOverrideUrlLoading` override to the article sheet so that http and https links open in the system browser instead of loading inside the sheet. Opening http links inside the webview can let attackers inject malicious scripts and steal private data from users.

The sheet has no toolbar or back control, so a link tapped today loads in place and leaves the reader with no clear way back. With this change normal web links go to the browser, other schemes keep the default behavior, and a missing handler is caught so it cannot crash the app.

Closes #12.